### PR TITLE
getProjectTypes function

### DIFF
--- a/codewind.yaml
+++ b/codewind.yaml
@@ -11,7 +11,7 @@ commands:
     command: appsody
     args:
       - init
-      - <subtype>
+      - $subtype
       - none
 detection: .appsody-config.yaml
 config:

--- a/codewind.yaml
+++ b/codewind.yaml
@@ -7,6 +7,12 @@ commands:
     command: appsody
     args:
       - init
+  - name: postProjectValidateWithType
+    command: appsody
+    args:
+      - init
+      - <subtype>
+      - none
 detection: .appsody-config.yaml
 config:
   containerAppRoot: /project/user-app

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -98,12 +98,11 @@ module.exports = {
                         continue;
 
                     const stack = cols[1];
-                    const version = cols[2];
 
                     stacks.push({
                         id: `${repo}/${stack}`,
-                        version,
-                        label: `${stack}:${version}`,
+                        version: cols[2],
+                        label: stack,
                         description: line.substring(descStart).trimRight()
                     });
                 }

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -65,7 +65,7 @@ module.exports = {
         });
     },
 
-    getSubtypes: async function() {
+    getProjectTypes: async function() {
         return new Promise((resolve, reject) => {
 
             // list of stacks start on 3rd line
@@ -74,7 +74,7 @@ module.exports = {
                 if (err)
                     return reject(err);
 
-                const stacks = [];
+                const projectTypes = [];
                 let descStart;
 
                 for (const line of stdout.split(os.EOL)) {
@@ -99,18 +99,21 @@ module.exports = {
 
                     const stack = cols[1];
 
-                    stacks.push({
-                        id: `${repo}/${stack}`,
-                        version: cols[2],
-                        label: stack,
-                        description: line.substring(descStart).trimRight()
+                    projectTypes.push({
+                        projectType: 'appsodyExtension',
+                        projectSubtypes: {
+                            prompt: 'Select the Appsody stack',
+                            items: [{
+                                id: `${repo}/${stack}`,
+                                version: cols[2],
+                                label: `Appsody ${stack}`,
+                                description: line.substring(descStart).trimRight()
+                            }]
+                        }
                     });
                 }
 
-                resolve({
-                    prompt: 'Select the Appsody stack',
-                    items: stacks
-                });
+                resolve(projectTypes);
             });
         });
     }

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -68,10 +68,6 @@ module.exports = {
     getSubtypes: async function() {
         return new Promise((resolve, reject) => {
 
-            // not support on k8s at the moment, return empty list
-            if (global.codewind && global.codewind.RUNNING_IN_K8S)
-                return resolve([]);
-
             // list of stacks start on 3rd line
             exec(`${__dirname}/appsody list | tail -n+3`, (err, stdout) => {
 
@@ -79,12 +75,42 @@ module.exports = {
                     return reject(err);
 
                 const stacks = [];
+                let descStart;
 
-                stdout.split(os.EOL).forEach((line) => {
-                    // TODO process the line
+                for (const line of stdout.split(os.EOL)) {
+                    
+                    // found header line, note where the description starts
+                    if (line.startsWith('REPO')) {
+                        descStart = line.indexOf('DESCRIPTION');
+                        continue;
+                    }
+
+                    // haven't found the header line yet
+                    if (!descStart)
+                        continue;
+
+                    // split the line: <repo> <id> <version> <templates> (leave <description> for later)
+                    const cols = line.substring(0, descStart).split(/\s+/);
+
+                    // check if it's a valid, non-experimental entry
+                    if (cols.length < 4 || cols[0] == 'experimental')
+                        continue;
+
+                    const stack = cols[1];
+                    const version = cols[2];
+
+                    stacks.push({
+                        id: `${cols[0]}/${stack}`,
+                        version,
+                        label: `${stack}:${version}`,
+                        description: line.substring(descStart).trimRight()
+                    });
+                }
+
+                resolve({
+                    prompt: 'Select the Appsody stack',
+                    items: stacks
                 });
-
-                resolve(stacks);
             });
         });
     }

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -91,16 +91,17 @@ module.exports = {
 
                     // split the line: <repo> <id> <version> <templates> (leave <description> for later)
                     const cols = line.substring(0, descStart).split(/\s+/);
+                    const repo = cols[0];
 
                     // check if it's a valid, non-experimental entry
-                    if (cols.length < 4 || cols[0] == 'experimental')
+                    if (cols.length < 4 || repo == 'experimental')
                         continue;
 
                     const stack = cols[1];
                     const version = cols[2];
 
                     stacks.push({
-                        id: `${cols[0]}/${stack}`,
+                        id: `${repo}/${stack}`,
                         version,
                         label: `${stack}:${version}`,
                         description: line.substring(descStart).trimRight()

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -63,5 +63,29 @@ module.exports = {
                 resolve(repos);
             });
         });
+    },
+
+    getSubtypes: async function() {
+        return new Promise((resolve, reject) => {
+
+            // not support on k8s at the moment, return empty list
+            if (global.codewind && global.codewind.RUNNING_IN_K8S)
+                return resolve([]);
+
+            // list of stacks start on 3rd line
+            exec(`${__dirname}/appsody list | tail -n+3`, (err, stdout) => {
+
+                if (err)
+                    return reject(err);
+
+                const stacks = [];
+
+                stdout.split(os.EOL).forEach((line) => {
+                    // TODO process the line
+                });
+
+                resolve(stacks);
+            });
+        });
     }
 }


### PR DESCRIPTION
For: https://github.com/eclipse/codewind/issues/292

Related PR: https://github.com/eclipse/codewind/pull/508

Sample output:

```json
[{
  "projectType": "appsodyExtension",
  "projectSubtypes": {
    "prompt": "Select the Appsody stack",
    "items": [
      {
        "id": "appsodyhub/java-microprofile",
        "version": "0.2.14",
        "label": "Appsody java-microprofile",
        "description": "Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven"
      }
    ]
  }
}]
```