### PR TITLE
Hooks to add and remove repository

### DIFF
--- a/.appsody.yaml
+++ b/.appsody.yaml
@@ -1,5 +1,5 @@
 home: /codewind-workspace/.appsody
 images: index.docker.io
-lastversioncheck: 2019-10-07 15:59:14 +0000 UTC
+lastversioncheck: 9999-12-31 23:59:59 +0000 UTC
 operator: https://github.com/appsody/appsody-operator/releases/latest/download
 tektonserver: ""

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is an extension to Codewind that adds support for [Appsody](http
 
 ## Installing the Appsody Extension on Codewind
 
-Download the latest [release](https://github.com/eclipse/codewind-appsody-extension/releases) and unzip or untar it under the Codewind workspace's `.extensions` folder, i.e.
+Download the desired build from [Eclipse Downloads](https://download.eclipse.org/codewind/codewind-appsody-extension/) and unzip the archive under the Codewind workspace's `.extensions` folder, i.e.
 
 `/some_path/codewind-workspace/.extensions/codewind-appsody-extension`
 
@@ -34,16 +34,6 @@ After installing the Appsody extension, the Appsody project templates will becom
 4. Run the command below. A docker image of the application will be built with the name *projectName*.
 
    `/codewind-workspace/.extensions/codewind-appsody-extension/appsody build`
-
-## Optional: Using the Same Appsody Configuration Between Local CLI and Codewind
-
-If you have a local install of the Appsody CLI, you can configure it to use the same configuration as Codewind.
-
-1. Open the `.appsody.yaml` configuration file that the Appsody CLI is using in an editor (by default, this file is located in your home directory, under the `.appsody` folder, but this can be changed via Appsody's [`--config`](https://appsody.dev/docs/using-appsody/cli-commands) flag)
-
-2. Change the `home` property to point the Codewind's copy of the Appsody configuration
-
-   `home: /some_path/codewind-workspace/.appsody`
 
 ## Current Limitations
 

--- a/codewind.yaml
+++ b/codewind.yaml
@@ -13,21 +13,7 @@ commands:
       - init
       - $subtype
       - none
-  - name: postRepositoryAdd
-    command: appsody
-    args:
-      - repo
-      - add
-      - $id
-      - $url
-  - name: postRepositoryRemove
-    command: appsody
-    args:
-      - repo
-      - remove
-      - $id
 detection: .appsody-config.yaml
 config:
   containerAppRoot: /project/user-app
   needsMount: true
-  style: Appsody

--- a/codewind.yaml
+++ b/codewind.yaml
@@ -13,6 +13,19 @@ commands:
       - init
       - $subtype
       - none
+  - name: postRepositoryAdd
+    command: appsody
+    args:
+      - repo
+      - add
+      - $name
+      - $url
+  - name: postRepositoryRemove
+    command: appsody
+    args:
+      - repo
+      - remove
+      - $name
 detection: .appsody-config.yaml
 config:
   containerAppRoot: /project/user-app

--- a/codewind.yaml
+++ b/codewind.yaml
@@ -18,15 +18,16 @@ commands:
     args:
       - repo
       - add
-      - $name
+      - $id
       - $url
   - name: postRepositoryRemove
     command: appsody
     args:
       - repo
       - remove
-      - $name
+      - $id
 detection: .appsody-config.yaml
 config:
   containerAppRoot: /project/user-app
   needsMount: true
+  style: Appsody

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -16,19 +16,16 @@
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 
-function canHandle(repository) {
-    return repository.id && 
-        Array.isArray(repository.projectStyles) &&
-        repository.projectStyles.includes('Appsody');
-}
-
 module.exports = {
 
+    canHandle: function(repository) {
+        return repository.projectStyles.includes('Appsody');
+    },
+    
     addRepository: async function(repository) {
         
         // no-op
-        if (!canHandle(repository) || 
-            !repository.url.endsWith('index.json'))
+        if (!repository.url.endsWith('index.json'))
             return;
 
         let url = repository.url;
@@ -38,11 +35,6 @@ module.exports = {
     },
 
     removeRepository: async function(repository) {
-        
-        // no-op
-        if (!canHandle(repository))
-            return;
-
         await exec(`${__dirname}/appsody repo remove ${repository.id}`);
     },
 

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -106,3 +106,12 @@ module.exports = {
         return projectTypes;
     }
 }
+
+// remove experimental repo on load
+module.exports.removeRepository({
+    id: 'experimental',
+    projectStyles: ['Appsody']
+})
+.catch((err) => {
+    console.warn(err.message);
+});

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -106,12 +106,3 @@ module.exports = {
         return projectTypes;
     }
 }
-
-// remove experimental repo on load
-module.exports.removeRepository({
-    id: 'experimental',
-    projectStyles: ['Appsody']
-})
-.catch((err) => {
-    console.warn(err.message);
-});

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -19,7 +19,9 @@ const exec = promisify(require('child_process').exec);
 module.exports = {
 
     canHandle: function(repository) {
-        return repository.projectStyles.includes('Appsody');
+        return repository.id &&
+            Array.isArray(repository.projectStyles) && 
+            repository.projectStyles.includes('Appsody');
     },
     
     addRepository: async function(repository) {

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -39,6 +39,7 @@ module.exports = {
                         url = url.substring(0, url.length - 10) + 'index.json';
 
                         repos.push({
+                            id: name,
                             name: `Appsody Stacks - ${name}`,
                             description: 'Use Appsody in Codewind to develop applications with sharable technology stacks.',
                             url

--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -74,7 +74,7 @@ module.exports = {
         return repos;
     },
 
-    getProjectTypes: async function() {
+    getProjectTypes: async function(id) {
 
         const projectTypes = [];
 


### PR DESCRIPTION
This work is part of https://github.com/eclipse/codewind/issues/564

- Add hooks `addRepository` and `removeRepository` for Codewind to call when a template repository is added/removed.
   - Codewind not calling these hooks yet
- It requires repos to have an `id`, which has already been merged via https://github.com/eclipse/codewind/pull/851