### PR TITLE
Fix app/build logs with the new logs architecture

### DIFF
--- a/.sh-extension
+++ b/.sh-extension
@@ -1,9 +1,13 @@
 {
     "requiredFiles": [],
-    "buildLogs": [],
-    "appLogs": [
-        "appsody"
-    ],
+    "appWorkspaceLogs": {
+        "files": {
+            "appsody": null
+        }
+    },
+    "appContainerLogs": {},
+    "buildWorkspaceLogs": {},
+    "buildContainerLogs": {},
     "appPort": {
         "nodejs-default": "3000",
         "java-default": "9080",


### PR DESCRIPTION
With the new logs architecture https://github.com/eclipse/codewind/pull/899, we will need this small change on the extension files to work correctly.

This PR needs to wait till https://github.com/eclipse/codewind/pull/899 goes in.

Signed-off-by: ssh24 <sakib@ibm.com>