### PR TITLE
Additional environment variables for appsody on Che

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,7 @@ cd "$ROOT" 2> /dev/null
 # export APPSODY_MOUNT_HOME=`$DIR/scripts/get-home.sh | xargs $util getWorkspacePathForVolumeMounting`
 if [ "$IN_K8" == "true" ]; then
 	export APPSODY_K8S_EXPERIMENTAL=TRUE
+	export CODEWIND_PROJECT_ID=$PROJECT_ID
 	hostWorkspacePath="/$CHE_WORKSPACE_ID/projects"
 else
 	hostWorkspacePath=`$util getWorkspacePathForVolumeMounting $HOST_WORKSPACE_DIRECTORY`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,6 +80,11 @@ cd "$ROOT" 2> /dev/null
 if [ "$IN_K8" == "true" ]; then
 	export APPSODY_K8S_EXPERIMENTAL=TRUE
 	export CODEWIND_PROJECT_ID=$PROJECT_ID
+	
+	source $DIR/scripts/export-self.sh
+	echo CODEWIND_OWNER_NAME=$CODEWIND_OWNER_NAME
+	echo CODEWIND_OWNER_UID=$CODEWIND_OWNER_UID
+
 	hostWorkspacePath="/$CHE_WORKSPACE_ID/projects"
 else
 	hostWorkspacePath=`$util getWorkspacePathForVolumeMounting $HOST_WORKSPACE_DIRECTORY`

--- a/scripts/export-self.sh
+++ b/scripts/export-self.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+###################################################################################
+#
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#
+###################################################################################
+
+PFE_LABEL="app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID"
+
+export CODEWIND_OWNER_NAME=`kubectl get rs --selector=$PFE_LABEL -o jsonpath='{.items[0].metadata.name}'`
+export CODEWIND_OWNER_UID=`kubectl get rs --selector=$PFE_LABEL -o jsonpath='{.items[0].metadata.uid}'`


### PR DESCRIPTION
Part of https://github.com/eclipse/codewind/issues/889

Export 3 additional environment variables for appsody:

- `CODEWIND_PROJECT_ID`
   - for Codewind to locate appsody service and create an ingress
- `CODEWIND_OWNER_NAME`
- `CODEWIND_OWNER_UID`
   - these 2 are for appsody to create resources with these as owner reference, so appsody resources can be garbage collected if Che workspace and/or PFE goes away