### PR TITLE
Appsody version bump + a fix

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -2,5 +2,5 @@
 
 This Codewind Appsody extension includes the following releases of the Appsody executables:
 
-- Appsody: [0.4.8](https://github.com/appsody/appsody/releases/tag/0.4.8)
+- Appsody: [0.4.10](https://github.com/appsody/appsody/releases/tag/0.4.10)
 - Appsody controller: [0.2.6](https://github.com/appsody/controller/releases/tag/0.2.6)

--- a/bin/README.md
+++ b/bin/README.md
@@ -2,5 +2,5 @@
 
 This Codewind Appsody extension includes the following releases of the Appsody executables:
 
-- Appsody: [0.4.11](https://github.com/appsody/appsody/releases/tag/0.4.11)
+- Appsody: [0.4.10](https://github.com/appsody/appsody/releases/tag/0.4.10)
 - Appsody controller: [0.2.6](https://github.com/appsody/controller/releases/tag/0.2.6)

--- a/bin/README.md
+++ b/bin/README.md
@@ -2,5 +2,5 @@
 
 This Codewind Appsody extension includes the following releases of the Appsody executables:
 
-- Appsody: [0.4.10](https://github.com/appsody/appsody/releases/tag/0.4.10)
+- Appsody: [0.4.11](https://github.com/appsody/appsody/releases/tag/0.4.11)
 - Appsody controller: [0.2.6](https://github.com/appsody/controller/releases/tag/0.2.6)

--- a/bin/pull.sh
+++ b/bin/pull.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-default_appsody_version=0.4.8
+default_appsody_version=0.4.10
 default_appsody_controller_version=0.2.6
 
 appsody_version=${APPSODY_VERSION}

--- a/bin/pull.sh
+++ b/bin/pull.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-default_appsody_version=0.4.11
+default_appsody_version=0.4.10
 default_appsody_controller_version=0.2.6
 
 appsody_version=${APPSODY_VERSION}

--- a/bin/pull.sh
+++ b/bin/pull.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-default_appsody_version=0.4.10
+default_appsody_version=0.4.11
 default_appsody_controller_version=0.2.6
 
 appsody_version=${APPSODY_VERSION}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,6 +87,14 @@ if [ "$IN_K8" == "true" ]; then
 
 	hostWorkspacePath="/$CHE_WORKSPACE_ID/projects"
 else
+	# a temporary workaround until controller mount is no longer needed	
+	tempBin="/mounted-workspace/.extensions/$EXT_NAME/bin"
+	if [ ! -f "$tempBin/appsody-controller" ]; then
+		rm -rf $tempBin
+		mkdir -p $tempBin
+		cp "$DIR/bin/appsody-controller" $tempBin
+	fi
+
 	hostWorkspacePath=`$util getWorkspacePathForVolumeMounting $HOST_WORKSPACE_DIRECTORY`
 fi
 export APPSODY_MOUNT_CONTROLLER="$hostWorkspacePath/.extensions/$EXT_NAME/bin/appsody-controller"
@@ -300,15 +308,6 @@ elif [ "$COMMAND" == "rebuild" ]; then
 	create
 # Just return configuration information as last line of output
 else
-	# a temporary workaround until controller mount is no longer needed
-	if [ "$IN_K8" != "true" ]; then
-		tempBin="/mounted-workspace/.extensions/$EXT_NAME/bin"
-		if [ ! -f "$tempBin/appsody-controller" ]; then
-			mkdir -p $tempBin
-			cp "$DIR/bin/appsody-controller" $tempBin
-		fi
-	fi
-
 	stack=`grep "stack: " .appsody-config.yaml`
 	knStack=`$DIR/scripts/get-stack.sh "$stack"`
 	echo -n "{ \"language\": \"$knStack\" }" > $LOG_FOLDER/settings.json


### PR DESCRIPTION
- Bump appsody version to `0.4.10`
- Fix for a problem found with the controller copying