### PR TITLE
master: docker fix

### DIFF
--- a/.appsody.yaml
+++ b/.appsody.yaml
@@ -1,5 +1,5 @@
 home: /codewind-workspace/.appsody
-images: index.docker.io
+images: docker.io
 lastversioncheck: 9999-12-31 23:59:59 +0000 UTC
 operator: https://github.com/appsody/appsody-operator/releases/latest/download
 tektonserver: ""


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Port of https://github.com/eclipse/codewind-appsody-extension/pull/71 to master