### PR TITLE
Read PFE network env file on appsody run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,8 +109,19 @@ function appsodyStart() {
 		cmd=debug
 	fi
 
-	if [ -f "env.properties" ]; then
-		dopts=--docker-options="--env-file=env.properties"
+	ENV_PROPERTIES_FILE=env.properties
+	PROJECT_LINKS_ENV_FILE="$ROOT/.codewind-project-links.env"
+	dopts=""
+	if [ -f "$ENV_PROPERTIES_FILE" ] && [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+		# if both files exist, merge them to resolve problem with docker-options
+		TEMP_ENV_FILE="/temp_env_file.env"
+		cat $ENV_PROPERTIES_FILE > $TEMP_ENV_FILE
+		cat $PROJECT_LINKS_ENV_FILE >> $TEMP_ENV_FILE
+		dopts=--docker-options="--env-file=$TEMP_ENV_FILE"
+	elif [ -f "$ENV_PROPERTIES_FILE" ]; then
+		dopts=--docker-options="--env-file=$ENV_PROPERTIES_FILE"
+	elif [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+		dopts=--docker-options="--env-file=$PROJECT_LINKS_ENV_FILE"
 	fi
 
 	$DIR/appsody $cmd --name $CONTAINER_NAME --network codewind_network -P $dopts |& tee -a $LOG_FOLDER/appsody.log &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,12 +109,12 @@ function appsodyStart() {
 		cmd=debug
 	fi
 
-	ENV_PROPERTIES_FILE=env.properties
+	ENV_PROPERTIES_FILE="$ROOT/env.properties"
 	PROJECT_LINKS_ENV_FILE="$ROOT/.codewind-project-links.env"
 	dopts=""
 	if [ -f "$ENV_PROPERTIES_FILE" ] && [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
 		# if both files exist, merge them to resolve problem with docker-options
-		TEMP_ENV_FILE="/temp_env_file.env"
+		TEMP_ENV_FILE="$ROOT/.codewind-merged-env-files.env"
 		cat $ENV_PROPERTIES_FILE > $TEMP_ENV_FILE
 		cat $PROJECT_LINKS_ENV_FILE >> $TEMP_ENV_FILE
 		dopts=--docker-options="--env-file=$TEMP_ENV_FILE"


### PR DESCRIPTION
### Summary
Issue related: https://github.com/eclipse/codewind/issues/2191
As part of the work to enable Codewind projects communicate via environment variables I need the to pass the network env file location through the `--env-file` Docker option to Appsody.

I had an issue with quote when trying to pass in two `--env-file` options to Appsody so I have resorted to merging the Appsody env file with the Networking env file if they both exist

### Testing
* Manually tested that the envs are picked up and put inside the container - works for Docker - will retest on K8s when the Kubernetes PR drops in the Codewind repository.


Signed-off-by: James Wallis <james.wallis1@ibm.com>