### PR TITLE
Publish builds to archive site instead of download site

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,11 +50,11 @@ pipeline {
                         fi
                         export OUTPUT_NAME="$REPO_NAME-$VERSION"
                         export OUTPUT_DIR="$WORKSPACE/output"
-                        export DOWNLOAD_AREA_URL="https://download.eclipse.org/codewind/$REPO_NAME"
+                        export DOWNLOAD_AREA_URL="https://archive.eclipse.org/codewind/$REPO_NAME"
                         export LATEST_DIR="latest"
                         export BUILD_INFO="build_info.properties"
                         export sshHost="genie.codewind@projects-storage.eclipse.org"
-                        export deployDir="/home/data/httpd/download.eclipse.org/codewind/$REPO_NAME"
+                        export deployDir="/home/data/httpd/archive.eclipse.org/codewind/$REPO_NAME"
                     
                         mkdir $OUTPUT_DIR
                         

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is an extension to Codewind that adds support for [Appsody](http
 
 ## Installing the Appsody Extension on Codewind
 
-Download the desired build from [Eclipse Downloads](https://download.eclipse.org/codewind/codewind-appsody-extension/) and unzip the archive under the Codewind workspace's `.extensions` folder, i.e.
+Download the desired build from [Eclipse Downloads](https://archive.eclipse.org/codewind/codewind-appsody-extension/) and unzip the archive under the Codewind workspace's `.extensions` folder, i.e.
 
 `/some_path/codewind-workspace/.extensions/codewind-appsody-extension`
 


### PR DESCRIPTION
Publish builds to archive site instead of download site

https://github.com/eclipse/codewind/issues/2700